### PR TITLE
Hotfix/tags

### DIFF
--- a/data-cleaning/notebook.ipynb
+++ b/data-cleaning/notebook.ipynb
@@ -2,10 +2,22 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "id": "9d22fa2b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[nltk_data] Downloading package punkt to /home/pedroch/nltk_data...\n",
+      "[nltk_data]   Package punkt is already up-to-date!\n",
+      "[nltk_data] Downloading package stopwords to\n",
+      "[nltk_data]     /home/pedroch/nltk_data...\n",
+      "[nltk_data]   Package stopwords is already up-to-date!\n"
+     ]
+    }
+   ],
    "source": [
     "import pandas as pd\n",
     "import numpy as np\n",
@@ -23,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "id": "26113611",
    "metadata": {},
    "outputs": [],
@@ -41,7 +53,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "id": "05cd93da",
    "metadata": {
     "scrolled": true
@@ -90,7 +102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "id": "c8310850",
    "metadata": {},
    "outputs": [],
@@ -100,7 +112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "id": "0bb3a9f9",
    "metadata": {
     "scrolled": true
@@ -112,7 +124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "id": "a11d88b9",
    "metadata": {},
    "outputs": [],
@@ -130,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "id": "3f1ff84f",
    "metadata": {},
    "outputs": [],
@@ -155,7 +167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "id": "79f1289c",
    "metadata": {},
    "outputs": [],
@@ -180,7 +192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "id": "f1b65ea4",
    "metadata": {},
    "outputs": [],
@@ -216,49 +228,49 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "id": "a3f2c4a7",
    "metadata": {},
    "outputs": [],
    "source": [
-    "removed = []\n",
+    "#removed = []\n",
     "\n",
     "# Create a copy of original dataframe\n",
     "df = complete_dataframe.copy()\n",
     "\n",
-    "for dataframe_index in complete_dataframe.index: \n",
-    "    video_texts = complete_dataframe['description'][dataframe_index] + complete_dataframe['title'][dataframe_index] + complete_dataframe['tags'][dataframe_index]\n",
-    "    language = detect(video_texts)\n",
+    "#for dataframe_index in complete_dataframe.index: \n",
+    "    #video_texts = complete_dataframe['description'][dataframe_index] + complete_dataframe['title'][dataframe_index] + complete_dataframe['tags'][dataframe_index]\n",
+    "    #language = detect(video_texts)\n",
     "    \n",
-    "    if(language not in accepted_languages):\n",
+    "    #if(language not in accepted_languages):\n",
     "        # print(language)\n",
     "        # print(complete_dataframe['url'][dataframe_index])\n",
-    "        removed.append({'lang': language, 'url': complete_dataframe['url'][dataframe_index]})\n",
-    "        df = df.drop(dataframe_index)\n",
+    "        #removed.append({'lang': language, 'url': complete_dataframe['url'][dataframe_index]})\n",
+    "        #df = df.drop(dataframe_index)\n",
     "\n",
-    "print(removed)"
+    "#print(removed)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "id": "b14d159c",
    "metadata": {
     "scrolled": true
    },
    "outputs": [],
    "source": [
-    "complete_dataframe.shape"
+    "#complete_dataframe.shape"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "id": "57262d51",
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.shape"
+    "#df.shape"
    ]
   },
   {
@@ -271,7 +283,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "id": "47fef19d",
    "metadata": {},
    "outputs": [],
@@ -289,10 +301,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "id": "4af22e79",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "url            0\n",
+      "title          0\n",
+      "description    0\n",
+      "tags           0\n",
+      "thumbnail      0\n",
+      "dtype: int64\n",
+      "shape before drop: (12849, 5)\n",
+      "indexes with empty titles: [706, 731, 786, 7889, 12179, 12188, 12201, 12228, 12253, 12301]\n",
+      "original shape: (12849, 5) updated shape: (12839, 5)\n",
+      "check if there is empty titles: 0\n"
+     ]
+    }
+   ],
    "source": [
     "#pd.set_option('display.max_rows', None)\n",
     "\n",
@@ -329,7 +358,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
    "id": "935db12a",
    "metadata": {},
    "outputs": [],
@@ -341,7 +370,7 @@
     "    if '' in unique_words:\n",
     "        unique_words.remove('')\n",
     "    # join words in unique_words, leaving an space between them, updating de row\n",
-    "    update_df['tags'][index] = ' '.join(unique_words)"
+    "    update_df['tags'][index] = ', '.join(unique_words)"
    ]
   },
   {
@@ -354,7 +383,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "id": "481e6bf0",
    "metadata": {},
    "outputs": [],
@@ -372,7 +401,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 41,
    "id": "2d223dea",
    "metadata": {},
    "outputs": [],
@@ -420,21 +449,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 42,
    "id": "500b858d",
    "metadata": {},
    "outputs": [],
    "source": [
     "nostopwords.to_json('./data_nostopwords2.json', force_ascii=False, orient='table', index=False)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "43b82e5d",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -453,7 +474,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/data-cleaning/notebook.ipynb
+++ b/data-cleaning/notebook.ipynb
@@ -1,522 +1,493 @@
 {
-  "cells": [
-    {
-      "cell_type": "code",
-      "execution_count": 25,
-      "id": "9d22fa2b",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[nltk_data] Downloading package punkt to /home/pedroch/nltk_data...\n",
-            "[nltk_data]   Package punkt is already up-to-date!\n",
-            "[nltk_data] Downloading package stopwords to\n",
-            "[nltk_data]     /home/pedroch/nltk_data...\n",
-            "[nltk_data]   Package stopwords is already up-to-date!\n"
-          ]
-        }
-      ],
-      "source": [
-        "import pandas as pd\n",
-        "import numpy as np\n",
-        "import json\n",
-        "import re # Regular expresions\n",
-        "\n",
-        "import nltk\n",
-        "nltk.download('punkt') \n",
-        "nltk.download('stopwords')\n",
-        "from nltk.corpus import stopwords\n",
-        "from nltk.tokenize import sent_tokenize, word_tokenize\n",
-        "\n",
-        "from langdetect import detect"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 26,
-      "id": "26113611",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "accepted_languages = ['es', 'en', 'it']"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "0446c63b",
-      "metadata": {},
-      "source": [
-        "# Read data"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 27,
-      "id": "05cd93da",
-      "metadata": {
-        "scrolled": true
-      },
-      "outputs": [],
-      "source": [
-        "# Open and decode the files\n",
-        "whayner_file = open('../scraper-data-whayner/data.json', encoding=\"utf8\")\n",
-        "whayner_data = json.load(whayner_file)\n",
-        "whayner_dataframe = pd.DataFrame(whayner_data['videos'])\n",
-        "\n",
-        "silvia_file = open('../scraper-data-silvia/data.json', encoding=\"utf8\")\n",
-        "silvia_data = json.load(silvia_file)\n",
-        "silvia_dataframe = pd.DataFrame(silvia_data['videos'])\n",
-        "\n",
-        "estefany_file = open('../scraper-data-estefany/data.json', encoding=\"utf8\")\n",
-        "estefany_data = json.load(estefany_file)\n",
-        "estefany_dataframe = pd.DataFrame(estefany_data['videos'])\n",
-        "\n",
-        "pedro_gomez_file = open('../scraper-data-pedrofelipe/data.json', encoding=\"utf8\")\n",
-        "pedro_gomez_data = json.load(pedro_gomez_file)\n",
-        "pedro_gomez_dataframe = pd.DataFrame(pedro_gomez_data['videos'])\n",
-        "\n",
-        "andres_file = open('../scraper-data-andres/data.json', encoding=\"utf8\")\n",
-        "andres_data = json.load(andres_file)\n",
-        "andres_dataframe = pd.DataFrame(andres_data['videos'])\n",
-        "\n",
-        "pedro_chaparro_file = open('../scraper-data-pedroandres/data.json', encoding=\"utf8\")\n",
-        "pedro_chaparro_data = json.load(pedro_chaparro_file)\n",
-        "pedro_chaparro_dataframe = pd.DataFrame(pedro_chaparro_data['videos'])\n",
-        "\n",
-        "# Concatenate in a single dataframe\n",
-        "complete_dataframe = pd.concat([whayner_dataframe, \n",
-        "                               silvia_dataframe, \n",
-        "                               estefany_dataframe, \n",
-        "                               pedro_gomez_dataframe, \n",
-        "                               andres_dataframe,\n",
-        "                               pedro_chaparro_dataframe])\n",
-        "\n",
-        "# Reset index\n",
-        "complete_dataframe = complete_dataframe.reset_index(drop=True)\n",
-        "\n",
-        "\n",
-        "# print(complete_dataframe.shape)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 28,
-      "id": "c8310850",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# complete_dataframe.head()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 29,
-      "id": "0bb3a9f9",
-      "metadata": {
-        "scrolled": true
-      },
-      "outputs": [],
-      "source": [
-        "# complete_dataframe.tail()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 30,
-      "id": "a11d88b9",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "#complete_dataframe.to_json('./initial.json', force_ascii=False, orient='table', index=False)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "372806d8",
-      "metadata": {},
-      "source": [
-        "# Convert to lowercase letters"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 31,
-      "id": "3f1ff84f",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "for dataframe_index in complete_dataframe.index: \n",
-        "    title = complete_dataframe['title'][dataframe_index]\n",
-        "    description = complete_dataframe['description'][dataframe_index]\n",
-        "    tags = complete_dataframe['tags'][dataframe_index]\n",
-        "    \n",
-        "    complete_dataframe['title'][dataframe_index]= title.lower()\n",
-        "    complete_dataframe['description'][dataframe_index] = description.lower()\n",
-        "    complete_dataframe['tags'][dataframe_index] = tags.lower()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "e9d6b99a",
-      "metadata": {},
-      "source": [
-        "# Remove duplicated entries"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "a33a785b",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "print(complete_dataframe.shape)\n",
-        "complete_dataframe.drop_duplicates(subset=['url'], keep='last', inplace=True, ignore_index=True)\n",
-        "print(complete_dataframe.shape)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "bac161f5",
-      "metadata": {},
-      "source": [
-        "# Remove links "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 32,
-      "id": "79f1289c",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "for dataframe_index in complete_dataframe.index: \n",
-        "    title = complete_dataframe['title'][dataframe_index]\n",
-        "    description = complete_dataframe['description'][dataframe_index]\n",
-        "    # Replace strings that starting with http or www with ''\n",
-        "    title = re.sub(r'http\\S+', '', title, flags=re.MULTILINE)\n",
-        "    description = re.sub(r'http\\S+', '', description, flags=re.MULTILINE) \n",
-        "    complete_dataframe['title'][dataframe_index] =  re.sub(r'www\\S+', '', title, flags=re.MULTILINE)\n",
-        "    complete_dataframe['description'][dataframe_index] = re.sub(r'www\\S+', '', description, flags=re.MULTILINE) "
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "3792de01",
-      "metadata": {},
-      "source": [
-        "# Remove unwanted characters (All that is not alfanum)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 33,
-      "id": "f1b65ea4",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "for dataframe_index in complete_dataframe.index: \n",
-        "    title = complete_dataframe['title'][dataframe_index]\n",
-        "    description = complete_dataframe['description'][dataframe_index]\n",
-        "    tags = complete_dataframe['tags'][dataframe_index]\n",
-        "\n",
-        "    # Remove not alfanumeric chars (with exceptions)\n",
-        "    new_title = re.sub(r'[^a-zA-Z0-9ñÑáéíóúÁÉÍÓÚ ]+', '', title)\n",
-        "    new_description = re.sub(r'[^a-zA-Z0-9ñÑáéíóúÁÉÍÓÚ ]+', '', description)\n",
-        "    new_tags = re.sub(r'[^a-zA-Z0-9ñÑáéíóúÁÉÍÓÚ, ]+', '', tags)\n",
-        "    \n",
-        "    # Remove redundant spaces\n",
-        "    new_title = re.sub(' +', ' ', new_title).strip()\n",
-        "    new_description = re.sub(' +', ' ', new_description).strip()\n",
-        "    new_tags = re.sub(' +', ' ', new_tags).strip()\n",
-        "\n",
-        "    # Replace\n",
-        "    complete_dataframe['title'][dataframe_index] = new_title\n",
-        "    complete_dataframe['description'][dataframe_index] = new_description\n",
-        "    complete_dataframe['tags'][dataframe_index] = new_tags"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "a0304742",
-      "metadata": {},
-      "source": [
-        "# Remove entries whose language is not english or spanish"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 34,
-      "id": "a3f2c4a7",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "#removed = []\n",
-        "\n",
-        "# Create a copy of original dataframe\n",
-        "df = complete_dataframe.copy()\n",
-        "\n",
-        "#for dataframe_index in complete_dataframe.index: \n",
-        "    #video_texts = complete_dataframe['description'][dataframe_index] + complete_dataframe['title'][dataframe_index] + complete_dataframe['tags'][dataframe_index]\n",
-        "    #language = detect(video_texts)\n",
-        "    \n",
-        "    #if(language not in accepted_languages):\n",
-        "        # print(language)\n",
-        "        # print(complete_dataframe['url'][dataframe_index])\n",
-        "        #removed.append({'lang': language, 'url': complete_dataframe['url'][dataframe_index]})\n",
-        "        #df = df.drop(dataframe_index)\n",
-        "\n",
-        "#print(removed)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 35,
-      "id": "b14d159c",
-      "metadata": {
-        "scrolled": true
-      },
-      "outputs": [],
-      "source": [
-        "#complete_dataframe.shape"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 36,
-      "id": "57262d51",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "#df.shape"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "1052d22b",
-      "metadata": {},
-      "source": [
-        "# Save as json"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 37,
-      "id": "47fef19d",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "#df.to_json('./data.json', force_ascii=False, orient='table', index=False)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "f3ae4c42",
-      "metadata": {},
-      "source": [
-        "# Counting null values - Deleting videos with empty titles - Removing repeated tag"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 38,
-      "id": "4af22e79",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "url            0\n",
-            "title          0\n",
-            "description    0\n",
-            "tags           0\n",
-            "thumbnail      0\n",
-            "dtype: int64\n",
-            "shape before drop: (12849, 5)\n",
-            "indexes with empty titles: [706, 731, 786, 7889, 12179, 12188, 12201, 12228, 12253, 12301]\n",
-            "original shape: (12849, 5) updated shape: (12839, 5)\n",
-            "check if there is empty titles: 0\n"
-          ]
-        }
-      ],
-      "source": [
-        "#pd.set_option('display.max_rows', None)\n",
-        "\n",
-        "# create a copy of last version of complete_dataframe\n",
-        "update_df = df.copy()\n",
-        "\n",
-        "# find indexes where there is just an empty string\n",
-        "indexes = update_df[update_df['title'] == ''].index.tolist()\n",
-        "# Counting null data in each column\n",
-        "print(update_df.isnull().sum())\n",
-        "\n",
-        "print(\"shape before drop:\", update_df.shape)\n",
-        "print(\"indexes with empty titles:\", indexes)\n",
-        "update_df = update_df.drop(index = indexes)\n",
-        "print(\"original shape:\", complete_dataframe.shape, \"updated shape:\", update_df.shape)\n",
-        "\n",
-        "#checking if there is another empty title in the updated\n",
-        "print(\"check if there is empty titles:\", len(update_df[update_df['title'] == ''].index))\n",
-        "\n",
-        "# reseting the index\n",
-        "update_df = update_df.reset_index(drop=True)\n",
-        "\n",
-        "# remove tag that contains: 'video, compartir, teléfono con cámara, teléfono con video, gratuito, subir'\n",
-        "update_df.loc[update_df['tags'] == 'video, compartir, teléfono con cámara, teléfono con video, gratuito, subir', 'tags'] = ''"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "158a87f6",
-      "metadata": {},
-      "source": [
-        "# Deleting repeated words in tags "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 39,
-      "id": "935db12a",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "for index in update_df['tags'].index:\n",
-        "    # take row, separate by ',' and remove space (strip) before and after each (map) word\n",
-        "    original = map(str.strip, update_df['tags'][index].split(','))\n",
-        "    unique_words = set(original)\n",
-        "    if '' in unique_words:\n",
-        "        unique_words.remove('')\n",
-        "    # join words in unique_words, leaving an space between them, updating de row\n",
-        "    update_df['tags'][index] = ', '.join(unique_words)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "8694e02b",
-      "metadata": {},
-      "source": [
-        "# Update data.json"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 40,
-      "id": "481e6bf0",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "update_df.to_json('./data.json', force_ascii=False, orient='table', index=False)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "377e301b",
-      "metadata": {},
-      "source": [
-        "# Remove stopwords in titles and descriptions"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 41,
-      "id": "2d223dea",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# function to select which set of stopwords choose\n",
-        "def selecting_stopwords(detected_lang):\n",
-        "    if detected_lang == 'es':\n",
-        "        return set(stopwords.words(\"spanish\"))\n",
-        "    elif detected_lang == 'en' or detected_lang == 'it':\n",
-        "        return set(stopwords.words(\"english\"))\n",
-        "\n",
-        "# function to keep stopwords in a list and later join the inner words\n",
-        "def removing_stopwords(sentence, detected_lang):\n",
-        "    no_stopw = []\n",
-        "    stopword = []\n",
-        "    [stopword.append(word) if word in selecting_stopwords(detected_lang) else no_stopw.append(word) for word in nltk.word_tokenize(sentence)]\n",
-        "    return ' '.join(no_stopw)\n",
-        "\n",
-        "nostopwords = update_df.copy()\n",
-        "\n",
-        "for df_index in nostopwords.index:\n",
-        "    for column in 'title', 'description':\n",
-        "        # we need try except when description is empty\n",
-        "        try:\n",
-        "            detected_lang = detect(nostopwords[column][df_index])\n",
-        "            sentence = nostopwords[column][df_index]\n",
-        "            # data treatment if the detect_lang is not en, sp or it\n",
-        "            if(detected_lang not in accepted_languages):\n",
-        "                first_clean = removing_stopwords(sentence, 'es')\n",
-        "                nostopwords[column][df_index] = removing_stopwords(first_clean, 'en')\n",
-        "            else:\n",
-        "                nostopwords[column][df_index] = removing_stopwords(sentence, detected_lang)\n",
-        "        except:\n",
-        "            #print(nostopwords[column][df_index], df_index)\n",
-        "            continue"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "599af47a",
-      "metadata": {},
-      "source": [
-        "# Saving json without stopwords"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 42,
-      "id": "500b858d",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "nostopwords.to_json('./data_nostopwords2.json', force_ascii=False, orient='table', index=False)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "43b82e5d",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "update_df['url'].nunique()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "3941caab",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "update_df.shape"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.10.4"
-    }
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9d22fa2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import json\n",
+    "import re # Regular expresions\n",
+    "\n",
+    "import nltk\n",
+    "nltk.download('punkt') \n",
+    "nltk.download('stopwords')\n",
+    "from nltk.corpus import stopwords\n",
+    "from nltk.tokenize import sent_tokenize, word_tokenize\n",
+    "\n",
+    "from langdetect import detect"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26113611",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "accepted_languages = ['es', 'en', 'it']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0446c63b",
+   "metadata": {},
+   "source": [
+    "# Read data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05cd93da",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Open and decode the files\n",
+    "whayner_file = open('../scraper-data-whayner/data.json', encoding=\"utf8\")\n",
+    "whayner_data = json.load(whayner_file)\n",
+    "whayner_dataframe = pd.DataFrame(whayner_data['videos'])\n",
+    "\n",
+    "silvia_file = open('../scraper-data-silvia/data.json', encoding=\"utf8\")\n",
+    "silvia_data = json.load(silvia_file)\n",
+    "silvia_dataframe = pd.DataFrame(silvia_data['videos'])\n",
+    "\n",
+    "estefany_file = open('../scraper-data-estefany/data.json', encoding=\"utf8\")\n",
+    "estefany_data = json.load(estefany_file)\n",
+    "estefany_dataframe = pd.DataFrame(estefany_data['videos'])\n",
+    "\n",
+    "pedro_gomez_file = open('../scraper-data-pedrofelipe/data.json', encoding=\"utf8\")\n",
+    "pedro_gomez_data = json.load(pedro_gomez_file)\n",
+    "pedro_gomez_dataframe = pd.DataFrame(pedro_gomez_data['videos'])\n",
+    "\n",
+    "andres_file = open('../scraper-data-andres/data.json', encoding=\"utf8\")\n",
+    "andres_data = json.load(andres_file)\n",
+    "andres_dataframe = pd.DataFrame(andres_data['videos'])\n",
+    "\n",
+    "pedro_chaparro_file = open('../scraper-data-pedroandres/data.json', encoding=\"utf8\")\n",
+    "pedro_chaparro_data = json.load(pedro_chaparro_file)\n",
+    "pedro_chaparro_dataframe = pd.DataFrame(pedro_chaparro_data['videos'])\n",
+    "\n",
+    "# Concatenate in a single dataframe\n",
+    "complete_dataframe = pd.concat([whayner_dataframe, \n",
+    "                               silvia_dataframe, \n",
+    "                               estefany_dataframe, \n",
+    "                               pedro_gomez_dataframe, \n",
+    "                               andres_dataframe,\n",
+    "                               pedro_chaparro_dataframe])\n",
+    "\n",
+    "# Reset index\n",
+    "complete_dataframe = complete_dataframe.reset_index(drop=True)\n",
+    "\n",
+    "\n",
+    "# print(complete_dataframe.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8310850",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# complete_dataframe.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0bb3a9f9",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# complete_dataframe.tail()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a11d88b9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#complete_dataframe.to_json('./initial.json', force_ascii=False, orient='table', index=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "372806d8",
+   "metadata": {},
+   "source": [
+    "# Convert to lowercase letters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f1ff84f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for dataframe_index in complete_dataframe.index: \n",
+    "    title = complete_dataframe['title'][dataframe_index]\n",
+    "    description = complete_dataframe['description'][dataframe_index]\n",
+    "    tags = complete_dataframe['tags'][dataframe_index]\n",
+    "    \n",
+    "    complete_dataframe['title'][dataframe_index]= title.lower()\n",
+    "    complete_dataframe['description'][dataframe_index] = description.lower()\n",
+    "    complete_dataframe['tags'][dataframe_index] = tags.lower()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e9d6b99a",
+   "metadata": {},
+   "source": [
+    "# Remove duplicated entries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a33a785b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(complete_dataframe.shape)\n",
+    "complete_dataframe.drop_duplicates(subset=['url'], keep='last', inplace=True, ignore_index=True)\n",
+    "print(complete_dataframe.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bac161f5",
+   "metadata": {},
+   "source": [
+    "# Remove links "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79f1289c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for dataframe_index in complete_dataframe.index: \n",
+    "    title = complete_dataframe['title'][dataframe_index]\n",
+    "    description = complete_dataframe['description'][dataframe_index]\n",
+    "    # Replace strings that starting with http or www with ''\n",
+    "    title = re.sub(r'http\\S+', '', title, flags=re.MULTILINE)\n",
+    "    description = re.sub(r'http\\S+', '', description, flags=re.MULTILINE) \n",
+    "    complete_dataframe['title'][dataframe_index] =  re.sub(r'www\\S+', '', title, flags=re.MULTILINE)\n",
+    "    complete_dataframe['description'][dataframe_index] = re.sub(r'www\\S+', '', description, flags=re.MULTILINE) "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3792de01",
+   "metadata": {},
+   "source": [
+    "# Remove unwanted characters (All that is not alfanum)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1b65ea4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for dataframe_index in complete_dataframe.index: \n",
+    "    title = complete_dataframe['title'][dataframe_index]\n",
+    "    description = complete_dataframe['description'][dataframe_index]\n",
+    "    tags = complete_dataframe['tags'][dataframe_index]\n",
+    "\n",
+    "    # Remove not alfanumeric chars (with exceptions)\n",
+    "    new_title = re.sub(r'[^a-zA-Z0-9ñÑáéíóúÁÉÍÓÚ ]+', '', title)\n",
+    "    new_description = re.sub(r'[^a-zA-Z0-9ñÑáéíóúÁÉÍÓÚ ]+', '', description)\n",
+    "    new_tags = re.sub(r'[^a-zA-Z0-9ñÑáéíóúÁÉÍÓÚ, ]+', '', tags)\n",
+    "    \n",
+    "    # Remove redundant spaces\n",
+    "    new_title = re.sub(' +', ' ', new_title).strip()\n",
+    "    new_description = re.sub(' +', ' ', new_description).strip()\n",
+    "    new_tags = re.sub(' +', ' ', new_tags).strip()\n",
+    "\n",
+    "    # Replace\n",
+    "    complete_dataframe['title'][dataframe_index] = new_title\n",
+    "    complete_dataframe['description'][dataframe_index] = new_description\n",
+    "    complete_dataframe['tags'][dataframe_index] = new_tags"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a0304742",
+   "metadata": {},
+   "source": [
+    "# Remove entries whose language is not english or spanish"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a3f2c4a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#removed = []\n",
+    "\n",
+    "# Create a copy of original dataframe\n",
+    "df = complete_dataframe.copy()\n",
+    "\n",
+    "#for dataframe_index in complete_dataframe.index: \n",
+    "    #video_texts = complete_dataframe['description'][dataframe_index] + complete_dataframe['title'][dataframe_index] + complete_dataframe['tags'][dataframe_index]\n",
+    "    #language = detect(video_texts)\n",
+    "    \n",
+    "    #if(language not in accepted_languages):\n",
+    "        # print(language)\n",
+    "        # print(complete_dataframe['url'][dataframe_index])\n",
+    "        #removed.append({'lang': language, 'url': complete_dataframe['url'][dataframe_index]})\n",
+    "        #df = df.drop(dataframe_index)\n",
+    "\n",
+    "#print(removed)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b14d159c",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "#complete_dataframe.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57262d51",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#df.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1052d22b",
+   "metadata": {},
+   "source": [
+    "# Save as json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47fef19d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#df.to_json('./data.json', force_ascii=False, orient='table', index=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3ae4c42",
+   "metadata": {},
+   "source": [
+    "# Counting null values - Deleting videos with empty titles - Removing repeated tag"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4af22e79",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#pd.set_option('display.max_rows', None)\n",
+    "\n",
+    "# create a copy of last version of complete_dataframe\n",
+    "update_df = df.copy()\n",
+    "\n",
+    "# find indexes where there is just an empty string\n",
+    "indexes = update_df[update_df['title'] == ''].index.tolist()\n",
+    "# Counting null data in each column\n",
+    "print(update_df.isnull().sum())\n",
+    "\n",
+    "print(\"shape before drop:\", update_df.shape)\n",
+    "print(\"indexes with empty titles:\", indexes)\n",
+    "update_df = update_df.drop(index = indexes)\n",
+    "print(\"original shape:\", complete_dataframe.shape, \"updated shape:\", update_df.shape)\n",
+    "\n",
+    "#checking if there is another empty title in the updated\n",
+    "print(\"check if there is empty titles:\", len(update_df[update_df['title'] == ''].index))\n",
+    "\n",
+    "# reseting the index\n",
+    "update_df = update_df.reset_index(drop=True)\n",
+    "\n",
+    "# remove tag that contains: 'video, compartir, teléfono con cámara, teléfono con video, gratuito, subir'\n",
+    "update_df.loc[update_df['tags'] == 'video, compartir, teléfono con cámara, teléfono con video, gratuito, subir', 'tags'] = ''"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "158a87f6",
+   "metadata": {},
+   "source": [
+    "# Deleting repeated words in tags "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "935db12a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for index in update_df['tags'].index:\n",
+    "    # take row, separate by ',' and remove space (strip) before and after each (map) word\n",
+    "    original = map(str.strip, update_df['tags'][index].split(','))\n",
+    "    unique_words = set(original)\n",
+    "    if '' in unique_words:\n",
+    "        unique_words.remove('')\n",
+    "    # join words in unique_words, leaving an space between them, updating de row\n",
+    "    update_df['tags'][index] = ', '.join(unique_words)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8694e02b",
+   "metadata": {},
+   "source": [
+    "# Update data.json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "481e6bf0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "update_df.to_json('./data.json', force_ascii=False, orient='table', index=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "377e301b",
+   "metadata": {},
+   "source": [
+    "# Remove stopwords in titles and descriptions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d223dea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# function to select which set of stopwords choose\n",
+    "def selecting_stopwords(detected_lang):\n",
+    "    if detected_lang == 'es':\n",
+    "        return set(stopwords.words(\"spanish\"))\n",
+    "    elif detected_lang == 'en' or detected_lang == 'it':\n",
+    "        return set(stopwords.words(\"english\"))\n",
+    "\n",
+    "# function to keep stopwords in a list and later join the inner words\n",
+    "def removing_stopwords(sentence, detected_lang):\n",
+    "    no_stopw = []\n",
+    "    stopword = []\n",
+    "    [stopword.append(word) if word in selecting_stopwords(detected_lang) else no_stopw.append(word) for word in nltk.word_tokenize(sentence)]\n",
+    "    return ' '.join(no_stopw)\n",
+    "\n",
+    "nostopwords = update_df.copy()\n",
+    "\n",
+    "for df_index in nostopwords.index:\n",
+    "    for column in 'title', 'description':\n",
+    "        # we need try except when description is empty\n",
+    "        try:\n",
+    "            detected_lang = detect(nostopwords[column][df_index])\n",
+    "            sentence = nostopwords[column][df_index]\n",
+    "            # data treatment if the detect_lang is not en, sp or it\n",
+    "            if(detected_lang not in accepted_languages):\n",
+    "                first_clean = removing_stopwords(sentence, 'es')\n",
+    "                nostopwords[column][df_index] = removing_stopwords(first_clean, 'en')\n",
+    "            else:\n",
+    "                nostopwords[column][df_index] = removing_stopwords(sentence, detected_lang)\n",
+    "        except:\n",
+    "            #print(nostopwords[column][df_index], df_index)\n",
+    "            continue"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "599af47a",
+   "metadata": {},
+   "source": [
+    "# Saving json without stopwords"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "500b858d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nostopwords.to_json('./data_nostopwords2.json', force_ascii=False, orient='table', index=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43b82e5d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "update_df['url'].nunique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3941caab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "update_df.shape"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
1. Se recuperan las comas eliminadas en el script de python. 
2. Se elimina la descripción de los json ya que no se enviará al cliente web, de este modo se reduce el peso (Hablado previamente con @Woynert). 
3. Se siguen conservando los 10122 vídeos únicos, solo se actualizan los tags y se elimina la descripción.

Código utilizado para la recuperación: https://gist.github.com/PedroChaparro/851874b5c39353a47b6ea50d96dbc7a1